### PR TITLE
Expose state on credits

### DIFF
--- a/resources/credits.rst
+++ b/resources/credits.rst
@@ -52,7 +52,7 @@ credit-view
     *string*. `ISO 8601 <http://www.w3.org/QA/Tips/iso-date>`_ date of when the state of this credit changed.
 
 ``state``
-    *string*. One of ``PROCESSING``, ``SUCCEEDED``, ``FAILED``
+    *string*. One of ``processing``, ``succeeded``, ``failed``
 
 ``fee``
     *integer*. The fee charged by Balanced for this credit.


### PR DESCRIPTION
Many people, have commented (see example IRC chat log below) that it's difficult to know the state of an ACH credit. Currently, they must deduce failure via absence of success or they must wait for a failed credit email to be sent by Balanced.

This email is hard to programmatically handle, this pull request exposes the state of the credit to allow programatic access to this information.

```
17:18 -!- ajsharp_zz is now known as ajsharp                                                                    
17:18 < ajsharp> Is there a way through the API to determine if a credit operation has failed?                  
17:18 < ajsharp> cc mjallday                                                                                    
17:18 < mjallday> hey mate                                                                                      
17:18 < ajsharp> hey                                                                                            
17:19 < mjallday> currently there isn't, it's a case of looking for absense of success                          
17:19 < mjallday> that's something we're actively working on right now to fix up                                    17:20 < mjallday> we've been discussing how to fix this here - https://github.com/balanced/balanced-api/issues/3    17:21  * ajsharp looks                                                                                          
17:22 < ajsharp> mjallday: that issue looks like it's about debits                                              
17:22 < ajsharp> Probably the same problem though, right?                                                       
17:22 < mjallday> that's correct, it's still the same problem                                                   
```
