### PR TITLE
Make Email address required for new account

### DIFF
--- a/resources/accounts.rst
+++ b/resources/accounts.rst
@@ -72,7 +72,7 @@ Request
     *optional* **string**. The display ``name`` of the account. Length must be **<=** ``128``. 
  
 ``email_address`` 
-    *optional* **string** or **null**. Email address of the account. It must be **unique** among all accounts 
+    **string** or **null**. Email address of the account. It must be **unique** among all accounts 
     on your marketplace. 
  
 ``card_uri`` 


### PR DESCRIPTION
At least for the PHP library you MUST pass in an email address, this is not reflected in the PHP docs on the website nor is it listed as required in the docs.
