### PR TITLE
Support Reversals for Push to Card

### DIFF
--- a/features/push_to_card.feature
+++ b/features/push_to_card.feature
@@ -51,7 +51,7 @@ Feature: Push to card
   Scenario: Push money to an existing debit card
     Given I have sufficient funds in my marketplace
     And I have a tokenized debit card
-    When I POST to /cards/:debit_card_href/credits with the JSON API body:
+    When I POST to /cards/:debit_card_id/credits with the JSON API body:
       """
       {
         "credits": [{

--- a/features/step_definitions/cards.rb
+++ b/features/step_definitions/cards.rb
@@ -28,8 +28,8 @@ Given(/^I have a tokenized debit card$/) do
       expiration_year: "2015"
     }
   )
-  @debit_card_href = @client['cards']['href']
-  @client.add_hydrate(:debit_card_href, @debit_card_href)
+  @debit_card_id = @client['cards']['id']
+  @client.add_hydrate(:debit_card_id, @debit_card_id)
 end
 
 Given(/^I have tokenized a customer card$/) do


### PR DESCRIPTION
Credits to a debit card should be treated the same way as credits to a bank account.
- [ ] Add ability to produce credit status of `pending` in tests #612
- [ ] Reverse a succeeded credit #620
- [ ] Reverse a pending credit #620

ping @cieplak
