### PR TITLE
Limited permission API keys

### DIFF
--- a/features/api_keys.feature
+++ b/features/api_keys.feature
@@ -83,3 +83,4 @@ Feature: API Keys
     And the response is valid according to the "customers" schema
     When I POST to /debits
     Then I should get a 401 Unauthorized status code
+    Then the response should contain "Not permitted to perform create on debits with this API key"

--- a/features/api_keys.feature
+++ b/features/api_keys.feature
@@ -63,7 +63,7 @@ Feature: API Keys
     """
     {
 	"api_keys": [{
-          "permissions": [
+          "scopes": [
 	    {
 	      "path": "/customers",
 	      "permissions": ["read", "write"]

--- a/features/api_keys.feature
+++ b/features/api_keys.feature
@@ -6,6 +6,10 @@ Feature: API Keys
   API keys are used to make authenticated requests by sending an HTTP Basic
   Auth header, using the key as the username, with no password.
 
+  API keys by default have full access to perform any operation on your
+  marketplace. You can create API keys with limited permissions that have
+  restricted access.
+
   Scenario: Create an API Key for a new marketplace
     To obtain a key, one must be created. This is done through an
     unauthenticated API request.
@@ -48,3 +52,28 @@ Feature: API Keys
     When I DELETE to /api_keys/:api_key giving the key
     Then I should get a 204 OK status code
     And there should be no response body
+
+  Scenario: Create an API key with limited permissions
+    By specifying permissions for a key you can restrict the operations that
+    it is able to perform to either being able to write (POST, DELETE, and PUT)
+    or read (GET) to a set of endpoints.
+
+    Given I have created an API key
+    When I POST to /api_keys with the body:
+    """
+    {
+	"api_keys": [{
+          "permissions": {
+	    "/customers": "rw",
+	    "/debits": "r"
+	  }
+	}]
+    }
+    """
+    Then I should get a 201 Created status code
+    And the response is valid according to the "api_keys" schema
+    When I POST to /customers
+    Then I should get a 201 Created status code
+    And the response is valid according to the "customers" schema
+    When I POST to /debits
+    Then I should get a 401 Unauthorized status code

--- a/features/api_keys.feature
+++ b/features/api_keys.feature
@@ -63,10 +63,16 @@ Feature: API Keys
     """
     {
 	"api_keys": [{
-          "permissions": {
-	    "/customers": "rw",
-	    "/debits": "r"
-	  }
+          "permissions": [
+	    {
+	      "path": "/customers",
+	      "permissions": ["read", "write"]
+            },
+	    {
+	      "path": "/debits",
+	      "permissions": ["read"]
+	    }
+	  ]
 	}]
     }
     """

--- a/features/debits.feature
+++ b/features/debits.feature
@@ -152,6 +152,7 @@ Feature: Debit a card or bank account
     Then I should get a 201 Created status code
     And the response is valid according to the "debits" schema
 
+  @focus
   Scenario: Debit a verified bank account
     Given I have a verified bank account
     When I make a POST request to the link "bank_accounts.debits" with the body:

--- a/features/step_definitions/api_keys.rb
+++ b/features/step_definitions/api_keys.rb
@@ -41,3 +41,7 @@ end
 Given(/^I have created more than one API keys$/) do
   2.times { step "I have created an API key" }
 end
+
+Then(/^the response should contain "([^"]*)"$/ do |expected_response|
+  @response.body.should include(expected_response)
+end

--- a/fixtures/_models/api_key.json
+++ b/fixtures/_models/api_key.json
@@ -27,7 +27,27 @@
             "additionalProperties": false
         },
 	"scopes": {
-            "type": "object"
+	    "type": "array",
+	    "items": {
+                "type": "object",
+		"properties": {
+		    "path": {
+		        "description": "A relative path that if matches the path of a request made with this API key will apply the related permissions to the call. Paths can have '*' wildcards but otherwise must match exactly.",
+		        "type": "string",
+			"pattern": "/(([A-z0-9\\-*])?/?)+"
+		    },
+		    "permissions": {
+		        "description": "A list of permissions this path is granted. 'read' maps to POST, PUT, DELETE, and PATCH HTTP verbs, 'write' to GET",
+		        "type": "array",
+			"items": {
+			    "enum": ["read", "write"]
+			},
+			"uniqueItems": true
+		    }
+		},
+		"requiredProperties": ["path", "permissions"],
+		"additionalProperties": false
+	    }
 	}
     },
     "required": [

--- a/fixtures/_models/api_key.json
+++ b/fixtures/_models/api_key.json
@@ -32,7 +32,7 @@
                 "type": "object",
 		"properties": {
 		    "path": {
-		        "description": "A relative path that if matches the path of a request made with this API key will apply the related permissions to the call. Paths can have '*' wildcards but otherwise must match exactly.",
+		        "description": "A relative path that, if matching the path of a request made with this API key, will apply the related permissions to the call. Paths can have '*' wildcards but otherwise must match exactly.",
 		        "type": "string",
 			"pattern": "/(([A-z0-9\\-*])?/?)+"
 		    },

--- a/fixtures/_models/api_key.json
+++ b/fixtures/_models/api_key.json
@@ -26,7 +26,7 @@
             "properties": {},
             "additionalProperties": false
         },
-	"permissions": {
+	"scopes": {
             "type": "object"
 	}
     },
@@ -36,7 +36,7 @@
         "created_at",
         "meta",
         "links",
-        "permissions"
+        "scopes"
     ],
     "additionalProperties": false
 }

--- a/fixtures/_models/api_key.json
+++ b/fixtures/_models/api_key.json
@@ -27,7 +27,7 @@
             "additionalProperties": false
         },
 	"permissions": {
-            "type": "object",
+            "type": "object"
 	}
     },
     "required": [

--- a/fixtures/_models/api_key.json
+++ b/fixtures/_models/api_key.json
@@ -25,7 +25,10 @@
             "type": "object",
             "properties": {},
             "additionalProperties": false
-        }
+        },
+	"permissions": {
+            "type": "object",
+	}
     },
     "required": [
         "id",

--- a/fixtures/_models/api_key.json
+++ b/fixtures/_models/api_key.json
@@ -35,7 +35,8 @@
         "href",
         "created_at",
         "meta",
-        "links"
+        "links",
+        "permissions"
     ],
     "additionalProperties": false
 }


### PR DESCRIPTION
This is a work in progress for #290 and #402

API keys that can be constrained to either read or write to a limited sub-set of endpoints.

E.g. 

A POST to `/api_keys`

``` json
{
    "api_keys": [{
        "scopes": [
            {
                "path": "/debits",
                "permission": ["read", "write"]
            }
        ]
    }]
}
```

will create an API key that can create customers and read all debits whose ID starts with `WD`. 

Note you can use asterisks as wildcards. URLS are matched exactly if a asterisk is not used so  `/customers/CU123`does not match a permission of  `{"/customers": "r"}` but it does match `{"/customers*": "r"}`

This does not implement OAuth as suggested in the [original issue](#290), this implementation seemed simpler for now but could be pushed in that direction once an MVP is out and working. I think this would be very handy for passing read only credentials for 3rd party integrations or auditors etc.

Internal implementation exists at https://github.com/balanced/balanced/issues/570 and https://github.com/balanced/balanced/pull/622
